### PR TITLE
Add test coverage

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,4 +1,4 @@
-name: test-coverage
+name: Test coverage
 
 on:
   push:
@@ -36,3 +36,8 @@ jobs:
         with:
           name: code-coverage-report
           path: ${{ github.workspace }}/nlohmann_json/build/html
+      - name: Publish report to Coveralls
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ${{ github.workspace }}/nlohmann_json/build/json.info.filtered.noexcept

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,14 +1,13 @@
 name: test-coverage
 
 on:
-  # TODO remove before merging
   push:
     branches:
       - nilseb_add_test_coverage
   pull_request:
-      types: [opened, reopened, synchronize]
-    merge_group:
-      types: [checks_requested]
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   ci_test_coverage:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,9 +1,6 @@
 name: Test coverage
 
 on:
-  push:
-    branches:
-      - nilseb_add_test_coverage
   pull_request:
     types: [opened, reopened, synchronize]
   merge_group:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,0 +1,39 @@
+name: test-coverage
+
+on:
+  # TODO remove before merging
+  push:
+    branches:
+      - nilseb_add_test_coverage
+  pull_request:
+      types: [opened, reopened, synchronize]
+    merge_group:
+      types: [checks_requested]
+
+jobs:
+  ci_test_coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies and de_DE locale
+        run: |
+          sudo apt-get clean
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake lcov ninja-build make locales gcc-multilib g++-multilib
+          sudo locale-gen de_DE
+          sudo update-locale
+      - uses: actions/checkout@v4.2.2
+        with:
+          submodules: true
+      - name: Make filterbr.py executable
+        run: chmod +x nlohmann_json/tests/thirdparty/imapdl/filterbr.py
+      - name: Run CMake
+        run: cmake -S . -B build -DJSON_CI=On
+        working-directory: nlohmann_json
+      - name: Build
+        run: cmake --build build --target ci_test_coverage
+        working-directory: nlohmann_json
+      - name: Archive coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: code-coverage-report
+          path: ${{ github.workspace }}/nlohmann_json/build/html

--- a/nlohmann_json/cmake/ci.cmake
+++ b/nlohmann_json/cmake/ci.cmake
@@ -237,14 +237,14 @@ add_custom_target(ci_test_coverage
         -DJSON_BuildTests=ON
         -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_coverage
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_coverage
-    COMMAND cd ${PROJECT_BINARY_DIR}/build_coverage && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
+    COMMAND cd ${PROJECT_BINARY_DIR}/build_coverage && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure -LE git_required
 
     COMMAND CXX=g++ ${CMAKE_COMMAND}
         -DCMAKE_BUILD_TYPE=Debug -GNinja -DCMAKE_CXX_FLAGS="-m32;--coverage;-fprofile-arcs;-ftest-coverage"
         -DJSON_BuildTests=ON -DJSON_32bitTest=ONLY
         -S${PROJECT_SOURCE_DIR} -B${PROJECT_BINARY_DIR}/build_coverage32
     COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}/build_coverage32
-    COMMAND cd ${PROJECT_BINARY_DIR}/build_coverage32 && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure
+    COMMAND cd ${PROJECT_BINARY_DIR}/build_coverage32 && ${CMAKE_CTEST_COMMAND} --parallel ${N} --output-on-failure -LE git_required
 
     COMMAND ${LCOV_TOOL} --directory . --capture --output-file json.info --rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors mismatch --ignore-errors unused
     COMMAND ${LCOV_TOOL} -e json.info ${SRC_FILES} --output-file json.info.filtered --rc branch_coverage=1 --ignore-errors unused

--- a/nlohmann_json/tests/src/BUILD
+++ b/nlohmann_json/tests/src/BUILD
@@ -4,7 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 genrule(
     name = "generate_test_data_hpp",
     outs = ["test_data.hpp"],
-    cmd = "echo '#define TEST_DATA_DIRECTORY \"json_test_data\"' > $@",
+    cmd = "echo '#define TEST_DATA_DIRECTORY \"nlohmann_json/tests/src/json_test_data\"' > $@",
 )
 
 cc_library(

--- a/nlohmann_json/tests/src/make_test_data_available.hpp
+++ b/nlohmann_json/tests/src/make_test_data_available.hpp
@@ -13,9 +13,6 @@
 #include <test_data.hpp>
 #include <doctest.h>
 
-#undef TEST_DATA_DIRECTORY
-#define TEST_DATA_DIRECTORY "nlohmann_json/tests/src/json_test_data"
-
 namespace utils
 {
 


### PR DESCRIPTION
Coverage results are uploaded as zip-folders in the workflow (you can browse them by opening index.html inside the folder) and to the [coveralls website](https://coveralls.io/github/score-json/inc_json). The test coverage is calculated using CMAKE as there currently seems to be a bug, as described in an [issue](https://github.com/score-json/inc_json/issues/16#issue-3177934586) in this repository. 